### PR TITLE
Fix order of statistics on the front page

### DIFF
--- a/ckan/lib/default/src/ckanext-romania_theme/ckanext/romania_theme/templates/home/snippets/stats.html
+++ b/ckan/lib/default/src/ckanext-romania_theme/ckanext/romania_theme/templates/home/snippets/stats.html
@@ -4,10 +4,16 @@
   <div class="inner">
     <h3>{{ _('{0} statistics').format(g.site_title) }}</h3>
     <ul>
-      <li class="width-33">
+      <li class="width-50">
         <a href="{{ h.url_for(controller='package', action='search') }}">
           <b>{{ h.SI_number_span(stats.dataset_count) }}</b>
           {{ _('dataset') if stats.dataset_count == 1 else _('datasets') }}
+        </a>
+      </li>
+      <li class="width-50">
+        <a href="{{ h.url_for(controller='package', action='search') }}">
+          <b>{{ h.get_number_of_files() }}</b>
+          {{ _('related item') if h.get_number_of_files() == 1 else _('related items') }}
         </a>
       </li>
       <li class="width-33">
@@ -22,13 +28,7 @@
           {{ _('group') if stats.group_count == 1 else _('groups') }}
         </a>
       </li>
-      <li class="width-50">
-        <a href="{{ h.url_for(controller='package', action='search') }}">
-          <b>{{ h.get_number_of_files() }}</b>
-          {{ _('related item') if h.get_number_of_files() == 1 else _('related items') }}
-        </a>
-      </li>
-      <li class="width-50">
+      <li class="width-33">
         <a href="{{ h.url_for(controller='package', action='search') }}">
           <b>{{ h.get_number_of_external_links() }}</b>
           {{ _('link') if stats.linkuri_externe == 1 else _('linkuri externe') }}


### PR DESCRIPTION
Order should be:

```
seturi de date - fisiere corelate
institutii - grupuri - link-uri externe
```