### PR TITLE
Bump limit for maximum filesize

### DIFF
--- a/ckan/etc/default/development.ini
+++ b/ckan/etc/default/development.ini
@@ -138,7 +138,7 @@ ckan.feeds.author_link =
 ofs.impl = pairtree
 ofs.storage_dir = /var/lib/ckan/default
 ckan.storage_path = /var/lib/ckan/default
-ckan.max_resource_size = 100
+ckan.max_resource_size = 1000
 
 #ckan.storage_path = /var/lib/ckan
 #ckan.max_resource_size = 10


### PR DESCRIPTION
We've bumped the limit on production, but we should keep prod/staging parity.

In `development.ini`:

```
ckan.max_resource_size = 1000
```